### PR TITLE
Add Client Work page test

### DIFF
--- a/tests/ClientWorkPage.ts
+++ b/tests/ClientWorkPage.ts
@@ -1,0 +1,13 @@
+import { Page } from '@playwright/test';
+
+export class ClientWorkPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async isClientWorkVisible() {
+    return await this.page.evaluate(() => document.body.innerText.includes('Client Work'));
+  }
+}

--- a/tests/HomePage.ts
+++ b/tests/HomePage.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+export class HomePage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async navigate() {
+    await this.page.goto('https://www.epam.com/');
+  }
+
+  async clickServices() {
+    await this.page.locator('a[href="/services"]').click();
+  }
+
+  async clickLearnMore() {
+    await this.page.locator('a[href="/services/client-work"]').click();
+  }
+}

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import { HomePage } from './HomePage';
+import { ClientWorkPage } from './ClientWorkPage';
+
+test('Navigate to Client Work page and verify text', async ({ page }) => {
+  const homePage = new HomePage(page);
+  const clientWorkPage = new ClientWorkPage(page);
+
+  await homePage.navigate();
+  await homePage.clickServices();
+  await homePage.clickLearnMore();
+
+  const isClientWorkVisible = await clientWorkPage.isClientWorkVisible();
+  expect(isClientWorkVisible).toBe(true);
+});


### PR DESCRIPTION
This PR adds a Playwright test scenario for navigating to the Client Work page and verifying the presence of the 'Client Work' text.